### PR TITLE
chore: use bash instead of shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ It collects the following information:
 
 ## Prerequisites
 
+* Requires Bash
 * Currently only works with Rook Ceph clusters
 * [Toolbox pod](https://rook.io/docs/rook/latest-release/Troubleshooting/ceph-toolbox/) must be running to collect some of the information needed by the debug script
 * `kubectl` configured with access to the Kubernetes clusters running the Rook Ceph clusters

--- a/gather-info.sh
+++ b/gather-info.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 CLUSTER_NAMESPACE="${CLUSTER_NAMESPACE:-rook-ceph}"
 OPERATOR_NAMESPACE="${OPERATOR_NAMESPACE:-}"
@@ -42,12 +42,14 @@ gatherKubernetesObjects() {
     # Get Rook Ceph CRs as YAML
     for crd in $(kubectl get crd --no-headers -o custom-columns=":metadata.name" | grep ".ceph.rook.io"); do
         kubectl get -A "${crd}" --output yaml > "rook_ceph-get-cr-${crd}"
+        echo "Collected yaml Rook CRD ${crd}"
     done
 }
 
 runCommandInToolsPod() {
-    command=$(echo "$*" | sed 's/ /_/g')
-    command=$(echo "$command" | sed 's/-/_/g')
+    command="$*"
+    command="${command// /_}"
+    command="${command//-/_}"
     kubectl -n "${CLUSTER_NAMESPACE}" exec -it deploy/rook-ceph-tools -- "${@}" > ceph-commands/"${command}"
 }
 
@@ -81,7 +83,7 @@ gatherCephCommands() {
 
 gatherCrashInfo() {
     for crash in $(kubectl -n "${CLUSTER_NAMESPACE}" exec -it deploy/rook-ceph-tools -- ceph crash ls-new); do
-        echo "crash info for $crash "
+        echo "Collected crash info for $crash"
         runCommandInToolsPod ceph crash info "$crash"
     done
 }


### PR DESCRIPTION
In hope for not mangling 

output were collected for get cr
```
➜  gather-logs-2023-06-09-d1KNHkoCTr ls
ceph-commands                   logs                                                        rook_ceph-get-cr-cephclusters.ceph.rook.io                   rook_ceph-get-cr-cephobjectstoreusers.ceph.rook.io
configmap_rook-config-override  rook_ceph-get-all                                           rook_ceph-get-cr-cephfilesystemmirrors.ceph.rook.io          rook_ceph-get-cr-cephobjectzonegroups.ceph.rook.io
configmaps                      rook_ceph-get-cr-cephblockpoolradosnamespaces.ceph.rook.io  rook_ceph-get-cr-cephfilesystems.ceph.rook.io                rook_ceph-get-cr-cephobjectzones.ceph.rook.io
deployments                     rook_ceph-get-cr-cephblockpools.ceph.rook.io                rook_ceph-get-cr-cephfilesystemsubvolumegroups.ceph.rook.io  rook_ceph-get-cr-cephrbdmirrors.ceph.rook.io
kubectl_get-nodes               rook_ceph-get-cr-cephbucketnotifications.ceph.rook.io       rook_ceph-get-cr-cephnfses.ceph.rook.io
kubectl_get-nodes-yaml          rook_ceph-get-cr-cephbuckettopics.ceph.rook.io              rook_ceph-get-cr-cephobjectrealms.ceph.rook.io
kubectl_version                 rook_ceph-get-cr-cephclients.ceph.rook.io                   rook_ceph-get-cr-cephobjectstores.ceph.rook.io
```
but they reran with ceph crash info function
```
 ceph_config_dump                                                                   ceph_crash_info_rook_ceph_get_cr_cephbucketnotifications.ceph.rook.io         ceph_health_detail
'ceph_crash_info_'$'\r'                                                             ceph_crash_info_rook_ceph_get_cr_cephbuckettopics.ceph.rook.io                ceph_mds_stat
 ceph_crash_info_2023_03_23T17:45:21.257560Z_4de2f225_0499_4505_9049_5d680842030e   ceph_crash_info_rook_ceph_get_cr_cephclients.ceph.rook.io                     ceph_mon_dump
 ceph_crash_info_ceph_commands                                                      ceph_crash_info_rook_ceph_get_cr_cephclusters.ceph.rook.io                    ceph_mon_stat
 ceph_crash_info_configmap_rook_config_override                                     ceph_crash_info_rook_ceph_get_cr_cephfilesystemmirrors.ceph.rook.io           ceph_osd_blocked_by
 ceph_crash_info_configmaps                                                         ceph_crash_info_rook_ceph_get_cr_cephfilesystems.ceph.rook.io                 ceph_osd_df_tree
 ceph_crash_info_deployments                                                        ceph_crash_info_rook_ceph_get_cr_cephfilesystemsubvolumegroups.ceph.rook.io   ceph_osd_dump
 ceph_crash_info_ENTITY                                                             ceph_crash_info_rook_ceph_get_cr_cephnfses.ceph.rook.io                       ceph_osd_numa_status
 ceph_crash_info_ID                                                                 ceph_crash_info_rook_ceph_get_cr_cephobjectrealms.ceph.rook.io                ceph_osd_perf
 ceph_crash_info_kubectl_get_nodes                                                  ceph_crash_info_rook_ceph_get_cr_cephobjectstores.ceph.rook.io                ceph_osd_pool_autoscale_status
 ceph_crash_info_kubectl_get_nodes_yaml                                             ceph_crash_info_rook_ceph_get_cr_cephobjectstoreusers.ceph.rook.io            ceph_osd_pool_ls_detail
 ceph_crash_info_kubectl_version                                                    ceph_crash_info_rook_ceph_get_cr_cephobjectzonegroups.ceph.rook.io            ceph_osd_tree
 ceph_crash_info_logs                                                               ceph_crash_info_rook_ceph_get_cr_cephobjectzones.ceph.rook.io                 ceph_pg_dump
 ceph_crash_info_mgr.a                                                              ceph_crash_info_rook_ceph_get_cr_cephrbdmirrors.ceph.rook.io                  ceph_pg_stat
 ceph_crash_info_NEW                                                                ceph_df                                                                       ceph_status
 ceph_crash_info_rook_ceph_get_all                                                  ceph_df_detail                                                                ceph_time_sync_status
 ceph_crash_info_rook_ceph_get_cr_cephblockpoolradosnamespaces.ceph.rook.io         ceph_fs_dump                                                                  ceph_versions
 ceph_crash_info_rook_ceph_get_cr_cephblockpools.ceph.rook.io                       ceph_fs_ls
```
I am not sure what might be racing, as the local script run works fine, @galexrt  if you have existing crashes in your cluster, can you give this a try?

Anyone has any feedback on the issue, also welcome, thanks!
